### PR TITLE
Fix

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -32,8 +32,8 @@ Route::middleware(App\Http\Middleware\BasicAuthMiddleware::class, App\Http\Middl
         Route::get('/', [ArticleServiceController::class, 'index']);
     });
     Route::prefix('profile')->group(function () {
-        Route::get('/', [ProfileController::class, 'show']);
-        Route::put('/', [ProfileController::class, 'update']);
+        Route::get('', [ProfileController::class, 'show']);
+        Route::put('', [ProfileController::class, 'update']);
     });
 });
 Route::get('qiita/{id}', FeedQiitaController::class);


### PR DESCRIPTION
This pull request includes a small change to the `routes/api.php` file. The change modifies the routes for the `profile` prefix to use an empty string instead of a forward slash in the `get` and `put` methods.

* [`routes/api.php`](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dL35-R36): Changed the `get` and `put` methods for the `profile` prefix to use an empty string instead of a forward slash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - プロファイルに関連するAPIエンドポイントのURL構造を統一するため、末尾のスラッシュを削除しました。これにより、ルーティングの一貫性が向上し、API利用時の挙動が安定することが期待されます。API呼び出し時は、新しいURL形式にご留意ください。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->