### PR TITLE
Fix: Vercel to Cloud Run(Google Cloud)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,13 +21,8 @@ RUN set -ex; \
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
-# 依存関係ファイルのみ先にコピー
-COPY composer.json composer.lock /var/www/html/
-
-# 作業ディレクトリ設定
+COPY . /var/www/html/
 WORKDIR /var/www/html
-
-# 依存関係のインストール（この時点ではアプリコードは存在しない）
 RUN composer install --no-dev --optimize-autoloader --no-interaction --prefer-dist
 
 # Storage ディレクトリとキャッシュディレクトリの作成と権限設定


### PR DESCRIPTION
This pull request makes a notable update to the `Dockerfile` by simplifying the build process and reorganizing the dependency installation workflow.

Changes to the `Dockerfile`:

* Removed the separate copying of `composer.json` and `composer.lock` files and replaced it with a single `COPY . /var/www/html/` command to copy the entire application codebase at once.
* Adjusted the workflow to install dependencies (`composer install`) after copying the full application code, ensuring the application code is available during dependency installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Dockerfileのファイルコピー手順を変更し、アプリケーション全体を一度にコピーするようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->